### PR TITLE
Add RetryNotifyWithContext function

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -37,13 +37,19 @@ func RetryNotify(operation Operation, b BackOff, notify Notify) error {
 // is closed.
 func RetryNotifyWithContext(ctx context.Context, operation Operation,
 	b BackOff, notify Notify) error {
-	var err error
-	var next time.Duration
-
 	var ctxDone <-chan struct{}
 	if ctx != nil {
 		ctxDone = ctx.Done()
 	}
+
+	select {
+	case <-ctxDone:
+		return ctx.Err()
+	default:
+	}
+
+	var err error
+	var next time.Duration
 
 	b.Reset()
 	for {

--- a/retry.go
+++ b/retry.go
@@ -34,7 +34,8 @@ func RetryNotify(operation Operation, b BackOff, notify Notify) error {
 // RetryNotifyWithContext calls notify function with the error and
 // wait duration for each failed attempt before sleep. If ctx is
 // non-nil, it will return early from a sleep when it's Done channel
-// is closed.
+// is closed, and it will also not call the operation if the context
+// is already canceled.
 func RetryNotifyWithContext(ctx context.Context, operation Operation,
 	b BackOff, notify Notify) error {
 	// If context is already canceled, return immediately.

--- a/retry_test.go
+++ b/retry_test.go
@@ -48,3 +48,23 @@ func TestRetryWithCanceledContext(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestRetryWithCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	called := false
+	f := func() error {
+		if called {
+			t.Error("This function shouldn't be called more than once")
+		} else {
+			cancel()
+			called = true
+		}
+		return errors.New("error")
+	}
+
+	err := RetryNotifyWithContext(ctx, f, NewExponentialBackOff(), nil)
+	if err != ctx.Err() {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -35,7 +35,7 @@ func TestRetry(t *testing.T) {
 	}
 }
 
-func TestRetryWithContext(t *testing.T) {
+func TestRetryWithCanceledContext(t *testing.T) {
 	f := func() error {
 		t.Error("This function shouldn't be called at all")
 		return errors.New("error")

--- a/retry_test.go
+++ b/retry_test.go
@@ -43,6 +43,7 @@ func TestRetryWithCanceledContext(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+
 	err := RetryNotifyWithContext(ctx, f, NewExponentialBackOff(), nil)
 	if err != ctx.Err() {
 		t.Errorf("unexpected error: %v", err)
@@ -51,6 +52,7 @@ func TestRetryWithCanceledContext(t *testing.T) {
 
 func TestRetryWithCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	called := false
 	f := func() error {

--- a/retry_test.go
+++ b/retry_test.go
@@ -36,20 +36,8 @@ func TestRetry(t *testing.T) {
 }
 
 func TestRetryWithContext(t *testing.T) {
-	const successOn = 3
-	var i = 0
-
-	// This function is successfull on "successOn" calls.
 	f := func() error {
-		i++
-		log.Printf("function is called %d. time\n", i)
-
-		if i == successOn {
-			log.Println("OK")
-			return nil
-		}
-
-		log.Println("error")
+		t.Error("This function shouldn't be called at all")
 		return errors.New("error")
 	}
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -12,7 +12,7 @@ func TestRetry(t *testing.T) {
 	const successOn = 3
 	var i = 0
 
-	// This function is successfull on "successOn" calls.
+	// This function is successful on "successOn" calls.
 	f := func() error {
 		i++
 		log.Printf("function is called %d. time\n", i)


### PR DESCRIPTION
This'll let us exit out of retries
quickly on context cancellation
(useful for keeping unit tests short).
